### PR TITLE
GH-2 Icon Reliability

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,10 +24,10 @@
 	"page_action": {
     "default_title": "__MSG_title__",
 		"default_icon": {
-			"16": "./icons/helix_logo_16.png",
-			"32": "./icons/helix_logo_32.png",
-			"48": "./icons/helix_logo_48.png",
-			"128": "./icons/helix_logo_128.png"
+			"16": "icons/helix_logo_16.png",
+			"32": "icons/helix_logo_32.png",
+			"48": "icons/helix_logo_48.png",
+			"128": "icons/helix_logo_128.png"
     }
 	},
   "commands": {
@@ -40,9 +40,9 @@
     }
   },
   "icons": {
-		"16": "./icons/helix_logo_16.png",
-		"32": "./icons/helix_logo_32.png",
-		"48": "./icons/helix_logo_48.png",
-		"128": "./icons/helix_logo_128.png"
+		"16": "icons/helix_logo_16.png",
+		"32": "icons/helix_logo_32.png",
+		"48": "icons/helix_logo_48.png",
+		"128": "icons/helix_logo_128.png"
 	}
 }


### PR DESCRIPTION
* Changed icon URLs to better match web extension API and chrome extension API recommendations.

Resolves: GH-2

Please ensure your pull request adheres to the following guidelines:
- [X] make sure to link the related issues in this description
- [X] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Research

Chrome Extension API : https://developer.chrome.com/docs/extensions/reference/browserAction/#manifest
Web Extension API: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action